### PR TITLE
Mesh quality analysis

### DIFF
--- a/libs/mesh_quality.py
+++ b/libs/mesh_quality.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+
+import os
+from datetime import datetime
+
+from qgis.core import (
+    QgsProject,
+    QgsMeshLayer,
+    QgsMesh,
+    QgsTriangle,
+    QgsMapLayerType,
+    QgsCoordinateTransform,
+    QgsCoordinateReferenceSystem,
+    
+)
+from qgis.gui import QgsVertexMarker
+
+from qgis.utils import iface
+
+from qgis.PyQt import uic
+from qgis.PyQt.QtCore import pyqtSignal
+from qgis.PyQt.QtGui import QIcon, QFont, QColor, QStandardItemModel, QStandardItem
+from qgis.PyQt.QtWidgets import QWidget
+
+FORM_CLASS, _ = uic.loadUiType(os.path.join(
+    os.path.dirname(__file__), '..', 'ui', 'mesh_quality.ui'))
+
+
+class MeshQuality(QWidget, FORM_CLASS):
+    closingTool = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super(MeshQuality, self).__init__(parent)
+        self.setupUi(self)
+        self.prt = parent
+        self.path_icon = os.path.join(os.path.dirname(__file__), '..', 'icons/')
+        
+        self.lay_mesh = None
+        self.lay_mesh_id = None
+        self.native_mesh = None
+        self.xform = None
+        
+        self.is_opening = True
+        
+        self.mdl_lay_mesh = QStandardItemModel()
+        self.cb_lay_mesh.setModel(self.mdl_lay_mesh)
+        
+        QgsProject.instance().layersAdded.connect(self.addLayers)
+        QgsProject.instance().layersRemoved.connect(self.removeLayers)
+        
+        self.cb_lay_mesh.currentIndexChanged.connect(self.mesh_lay_changed)
+        
+        self.btn_analyse_mesh.clicked.connect(self.analyse_mesh)
+        
+        for lay in QgsProject.instance().mapLayers().values():
+            self.analyse_layer(lay)
+            
+        self.is_opening = False
+        
+    def closeEvent(self, event):
+        self.closingTool.emit()
+        event.accept()
+
+    def addLayers(self, layers):
+        for lay in layers:
+            self.analyse_layer(lay)
+
+    def removeLayers(self, layers):
+        for mdl in [self.mdl_lay_culv, self.mdl_lay_mesh]:
+            for r in range(mdl.rowCount() - 1, -1, -1):
+                if mdl.item(r, 0).data(32) in layers:
+                    mdl.takeRow(r)
+
+    def analyse_layer(self, lay):
+        if lay.type() == QgsMapLayerType.MeshLayer:
+            itm = QStandardItem()
+            itm.setData(lay.name(), 0)
+            itm.setData(lay.id(), 32)
+            self.mdl_lay_mesh.appendRow(itm)
+            self.mdl_lay_mesh.sort(0)
+
+    ######################################################################################
+    #                                                                                    #
+    #                                     MESH LAYER                                     #
+    #                                                                                    #
+    ######################################################################################
+
+    def mesh_lay_changed(self):
+        lay_id = self.cb_lay_mesh.currentData(32)
+        if self.lay_mesh_id == lay_id:
+            return
+
+        if lay_id:
+            self.lay_mesh = QgsProject.instance().mapLayer(lay_id)
+            self.lay_mesh_id = lay_id
+            self.xform = QgsCoordinateTransform(
+                self.lay_mesh.crs(),
+                QgsProject.instance().crs(),
+                QgsProject.instance(),
+            )
+        else:
+            self.lay_mesh = None
+            self.lay_mesh_id = None
+            self.native_mesh = None
+            self.xform = None
+        self.cur_mesh_changed()
+
+    def cur_mesh_changed(self):
+        if self.lay_mesh is not None:
+            self.write_log(f"Current mesh changed : {self.lay_mesh.name()}")
+            self.native_mesh = QgsMesh()
+            self.lay_mesh.dataProvider().populateMesh(self.native_mesh)
+            # self.faces = self.create_faces_spatial_index()
+
+            # mesh_prov = self.lay_mesh.dataProvider()
+            # for i in range(mesh_prov.datasetGroupCount()):
+                # itm = QStandardItem()
+                # itm.setData(mesh_prov.datasetGroupMetadata(i).name(), 0)
+                # itm.setData(i, 32)
+                # self.mdl_mesh_dataset.appendRow(itm)
+
+    def analyse_mesh(self):
+        if not self.lay_mesh:
+            self.write_log("No mesh selected", 2)
+            return
+        
+        wasInEditMode = False
+        if self.lay_mesh.isEditable():
+            wasInEditMode = True
+            # self.lay_mesh.stopFrameEditing(self.xform)
+            self.write_log("Stop edit mode first", 2)
+            return
+        
+        
+        
+        
+            
+        
+        
+
+    def write_log(self, txt, mode=1):
+        self.log.setTextColor(QColor("black"))
+        self.log.setFontWeight(QFont.Bold)
+        self.log.append(f"{datetime.now().strftime('%H:%M:%S')} - ")
+        if mode == 0:
+            self.log.setTextColor(QColor("green"))
+        elif mode == 1:
+            self.log.setTextColor(QColor("black"))
+        elif mode == 2:
+            self.log.setTextColor(QColor("red"))
+        self.log.setFontWeight(QFont.Normal)
+        self.log.insertPlainText(txt)
+        self.log.verticalScrollBar().setValue(self.log.verticalScrollBar().maximum())
+    

--- a/libs/mesh_quality.py
+++ b/libs/mesh_quality.py
@@ -1,83 +1,59 @@
 # -*- coding: utf-8 -*-
 
+import math
 import os
 from datetime import datetime
 
 from qgis.core import (
-    QgsProject,
-    QgsMeshLayer,
-    QgsMesh,
-    QgsTriangle,
-    QgsMapLayerType,
     QgsCoordinateTransform,
-    QgsCoordinateReferenceSystem,
-    
+    QgsFeature,
+    QgsLineString,
+    QgsMapLayerProxyModel,
+    QgsMapLayerType,
+    QgsMesh,
+    QgsPointXY,
+    QgsProject,
+    QgsTriangle,
+    QgsVectorLayer,
 )
 from qgis.gui import QgsVertexMarker
-
+from qgis.PyQt import uic
+from qgis.PyQt.QtGui import QColor, QFont, QIcon, QStandardItem, QStandardItemModel
+from qgis.PyQt.QtWidgets import QWidget
 from qgis.utils import iface
 
-from qgis.PyQt import uic
-from qgis.PyQt.QtCore import pyqtSignal
-from qgis.PyQt.QtGui import QIcon, QFont, QColor, QStandardItemModel, QStandardItem
-from qgis.PyQt.QtWidgets import QWidget
-
-FORM_CLASS, _ = uic.loadUiType(os.path.join(
-    os.path.dirname(__file__), '..', 'ui', 'mesh_quality.ui'))
+FORM_CLASS, _ = uic.loadUiType(os.path.join(os.path.dirname(__file__), "..", "ui", "mesh_quality.ui"))
 
 
 class MeshQuality(QWidget, FORM_CLASS):
-    closingTool = pyqtSignal()
 
     def __init__(self, parent=None):
         super(MeshQuality, self).__init__(parent)
         self.setupUi(self)
+        self.iface = iface
+        self.canvas = self.iface.mapCanvas()
+        self.project = QgsProject.instance()
         self.prt = parent
-        self.path_icon = os.path.join(os.path.dirname(__file__), '..', 'icons/')
-        
-        self.lay_mesh = None
-        self.lay_mesh_id = None
+        self.path_icon = os.path.join(os.path.dirname(__file__), "..", "icons/")
+
+        self.lay_mesh = self.mMapLayerComboBox.currentLayer()
         self.native_mesh = None
+        self.native_mesh_faces_count = None
         self.xform = None
-        
-        self.is_opening = True
-        
-        self.mdl_lay_mesh = QStandardItemModel()
-        self.cb_lay_mesh.setModel(self.mdl_lay_mesh)
-        
-        QgsProject.instance().layersAdded.connect(self.addLayers)
-        QgsProject.instance().layersRemoved.connect(self.removeLayers)
-        
-        self.cb_lay_mesh.currentIndexChanged.connect(self.mesh_lay_changed)
-        
+
+        self.mesh_lay_changed()
+
+        self.bad_faces_center = []
+
+        self.mMapLayerComboBox.setFilters(QgsMapLayerProxyModel.MeshLayer)
+        self.mMapLayerComboBox.layerChanged.connect(self.mesh_lay_changed)
+
         self.btn_analyse_mesh.clicked.connect(self.analyse_mesh)
-        
-        for lay in QgsProject.instance().mapLayers().values():
-            self.analyse_layer(lay)
-            
-        self.is_opening = False
-        
+        self.btn_reset_marker.clicked.connect(self.resetVertexMarker)
+
     def closeEvent(self, event):
-        self.closingTool.emit()
+        self.resetVertexMarker()
         event.accept()
-
-    def addLayers(self, layers):
-        for lay in layers:
-            self.analyse_layer(lay)
-
-    def removeLayers(self, layers):
-        for mdl in [self.mdl_lay_culv, self.mdl_lay_mesh]:
-            for r in range(mdl.rowCount() - 1, -1, -1):
-                if mdl.item(r, 0).data(32) in layers:
-                    mdl.takeRow(r)
-
-    def analyse_layer(self, lay):
-        if lay.type() == QgsMapLayerType.MeshLayer:
-            itm = QStandardItem()
-            itm.setData(lay.name(), 0)
-            itm.setData(lay.id(), 32)
-            self.mdl_lay_mesh.appendRow(itm)
-            self.mdl_lay_mesh.sort(0)
 
     ######################################################################################
     #                                                                                    #
@@ -86,57 +62,122 @@ class MeshQuality(QWidget, FORM_CLASS):
     ######################################################################################
 
     def mesh_lay_changed(self):
-        lay_id = self.cb_lay_mesh.currentData(32)
-        if self.lay_mesh_id == lay_id:
-            return
+        self.lay_mesh = self.mMapLayerComboBox.currentLayer()
 
-        if lay_id:
-            self.lay_mesh = QgsProject.instance().mapLayer(lay_id)
-            self.lay_mesh_id = lay_id
+        if self.lay_mesh:
+            self.write_log(f"Current mesh changed : {self.lay_mesh.name()}")
             self.xform = QgsCoordinateTransform(
                 self.lay_mesh.crs(),
-                QgsProject.instance().crs(),
-                QgsProject.instance(),
+                self.canvas.mapSettings().destinationCrs(),
+                self.project,
             )
         else:
             self.lay_mesh = None
-            self.lay_mesh_id = None
             self.native_mesh = None
             self.xform = None
         self.cur_mesh_changed()
 
     def cur_mesh_changed(self):
-        if self.lay_mesh is not None:
-            self.write_log(f"Current mesh changed : {self.lay_mesh.name()}")
+        if self.lay_mesh:
             self.native_mesh = QgsMesh()
             self.lay_mesh.dataProvider().populateMesh(self.native_mesh)
-            # self.faces = self.create_faces_spatial_index()
-
-            # mesh_prov = self.lay_mesh.dataProvider()
-            # for i in range(mesh_prov.datasetGroupCount()):
-                # itm = QStandardItem()
-                # itm.setData(mesh_prov.datasetGroupMetadata(i).name(), 0)
-                # itm.setData(i, 32)
-                # self.mdl_mesh_dataset.appendRow(itm)
 
     def analyse_mesh(self):
         if not self.lay_mesh:
             self.write_log("No mesh selected", 2)
-            return
-        
+
         wasInEditMode = False
         if self.lay_mesh.isEditable():
             wasInEditMode = True
-            # self.lay_mesh.stopFrameEditing(self.xform)
-            self.write_log("Stop edit mode first", 2)
-            return
-        
-        
-        
-        
+            self.lay_mesh.commitFrameEditing(self.xform, False)
+            self.cur_mesh_changed()
+
+        self.resetVertexMarker()
+
+        self.native_mesh_faces_count = self.native_mesh.faceCount()
+
+        for index in range(self.native_mesh_faces_count):
+            face = self.native_mesh.face(index)
+            points = [self.native_mesh.vertex(v) for v in face]
+            triangle = QgsTriangle()
+            triangle.setExteriorRing(QgsLineString(points))
+
+            if self.chk_equilateralness.isChecked():
+                if any(math.degrees(a) < self.qdsb_bad_angle_1.value() for a in triangle.angles()):
+                    self.addVertexMarker(triangle.centroid(), "bad_angle_1")
+                elif any(math.degrees(a) < self.qdsb_bad_angle_2.value() for a in triangle.angles()):
+                    self.addVertexMarker(triangle.centroid(), "bad_angle_2")
+                elif any(math.degrees(a) < self.qdsb_bad_angle_3.value() for a in triangle.angles()):
+                    self.addVertexMarker(triangle.centroid(), "bad_angle_3")
             
-        
-        
+            if self.chk_min_size.isChecked():
+                if any(l < self.qdsb_min_element_length.value() for l in triangle.lengths()):
+                    self.addVertexMarker(triangle.centroid(), "bad_length")
+                if triangle.area() < self.qdsb_min_face_area.value():
+                    self.addVertexMarker(triangle.centroid(), "bad_area")
+
+        if self.bad_faces_center:
+            self.btn_reset_marker.setEnabled(True)
+            self.showVertexMarker()
+
+        if wasInEditMode:
+            self.lay_mesh.startFrameEditing(self.xform)
+
+    def addVertexMarker(self, point, type):
+        marker = QgsVertexMarker(self.canvas)
+        marker.setCenter(QgsPointXY(point))
+
+        if type == "bad_angle_1":
+            marker.setColor(QColor(255, 0, 0))
+            marker.setPenWidth(2)
+            marker.setIconType(QgsVertexMarker.ICON_X)
+            marker.setIconSize(10)
+        elif type == "bad_angle_2":
+            marker.setColor(QColor(255, 255, 0))
+            marker.setPenWidth(2)
+            marker.setIconType(QgsVertexMarker.ICON_X)
+            marker.setIconSize(10)
+        elif type == "bad_angle_3":
+            marker.setColor(QColor(0, 0, 255))
+            marker.setPenWidth(2)
+            marker.setIconType(QgsVertexMarker.ICON_X)
+            marker.setIconSize(10)
+        elif type == "bad_length":
+            marker.setColor(QColor(255, 0, 0))
+            marker.setPenWidth(2)
+            marker.setIconType(QgsVertexMarker.ICON_BOX)
+            marker.setIconSize(10)
+        elif type == "bad_area":
+            marker.setColor(QColor(255, 0, 0))
+            marker.setPenWidth(2)
+            marker.setIconType(QgsVertexMarker.ICON_TRIANGLE)
+            marker.setIconSize(10)
+
+        marker.hide()
+
+        self.bad_faces_center.append(marker)
+
+    def showVertexMarker(self, id=None):
+        if id:
+            marker[id].show()
+        else:
+            for marker in self.bad_faces_center:
+                marker.show()
+
+    def hideVertexMarker(self, id=None):
+        if id:
+            marker[id].hide()
+        else:
+            for marker in self.bad_faces_center:
+                marker.hide()
+
+    def resetVertexMarker(self):
+        if self.bad_faces_center:
+            for marker in self.bad_faces_center:
+                marker.hide()
+                self.canvas.scene().removeItem(marker)
+        self.bad_faces_center = []
+        self.btn_reset_marker.setEnabled(False)
 
     def write_log(self, txt, mode=1):
         self.log.setTextColor(QColor("black"))
@@ -151,4 +192,3 @@ class MeshQuality(QWidget, FORM_CLASS):
         self.log.setFontWeight(QFont.Normal)
         self.log.insertPlainText(txt)
         self.log.verticalScrollBar().setValue(self.log.verticalScrollBar().maximum())
-    

--- a/libs/mesh_quality.py
+++ b/libs/mesh_quality.py
@@ -26,7 +26,6 @@ FORM_CLASS, _ = uic.loadUiType(os.path.join(os.path.dirname(__file__), "..", "ui
 
 
 class MeshQuality(QWidget, FORM_CLASS):
-
     def __init__(self, parent=None):
         super(MeshQuality, self).__init__(parent)
         self.setupUi(self)
@@ -109,7 +108,7 @@ class MeshQuality(QWidget, FORM_CLASS):
                     self.addVertexMarker(triangle.centroid(), "bad_angle_2")
                 elif any(math.degrees(a) < self.qdsb_bad_angle_3.value() for a in triangle.angles()):
                     self.addVertexMarker(triangle.centroid(), "bad_angle_3")
-            
+
             if self.chk_min_size.isChecked():
                 if any(l < self.qdsb_min_element_length.value() for l in triangle.lengths()):
                     self.addVertexMarker(triangle.centroid(), "bad_length")

--- a/telemac_tools.py
+++ b/telemac_tools.py
@@ -192,7 +192,7 @@ class TelemacTools:
     def onClosePlugin(self):
         """Cleanup necessary items here when plugin dockwidget is closed"""
 
-        #print "** CLOSING TelemacTools"
+        self.dockwidget.widget().close()
 
         # disconnects
         self.dockwidget.closingPlugin.disconnect(self.onClosePlugin)

--- a/telemac_tools.py
+++ b/telemac_tools.py
@@ -29,6 +29,7 @@ from qgis.PyQt.QtWidgets import QAction, QToolBar, QDockWidget, QWidget
 
 # Import the code for the DockWidget
 from .libs.culvert_manager import CulvertManager
+from .libs.mesh_quality import MeshQuality
 import os.path
 
 
@@ -177,8 +178,13 @@ class TelemacTools:
             parent=self.iface.mainWindow())
         self.add_action(
             icon_path,
-            text=self.tr(u'Telemac Tool 2'),
+            text=self.tr(u'Mesh Quality Analysis'),
             callback=lambda: self.run(2),
+            parent=self.iface.mainWindow())
+        self.add_action(
+            icon_path,
+            text=self.tr(u'Telemac Tool 2'),
+            callback=lambda: self.run(3),
             parent=self.iface.mainWindow())
 
     #--------------------------------------------------------------------------
@@ -239,12 +245,15 @@ class TelemacTools:
                 self.dockwidget.show()
 
         if self.dockwidget.widget():
-            print (self.dockwidget.widget().close())
+            print(self.dockwidget.widget().close())
 
         if tool == 1:
             self.dockwidget.setWindowTitle("Telemac - Culvert Manager")
             self.dockwidget.setWidget(CulvertManager())
         elif tool == 2:
+            self.dockwidget.setWindowTitle("Telemac - Mesh Quality Analysis")
+            self.dockwidget.setWidget(MeshQuality())
+        elif tool == 3:
             self.dockwidget.setWindowTitle("Telemac - Tool {}".format(tool))
             self.dockwidget.setWidget(QWidget())
         else:

--- a/telemac_tools.py
+++ b/telemac_tools.py
@@ -21,16 +21,19 @@
  *                                                                         *
  ***************************************************************************/
 """
-from qgis.PyQt.QtCore import QSettings, QTranslator, QCoreApplication, Qt, pyqtSignal
+import os.path
+
+from qgis.core import Qgis
+from qgis.PyQt.QtCore import QCoreApplication, QSettings, Qt, QTranslator, pyqtSignal
 from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtWidgets import QAction, QToolBar, QDockWidget, QWidget
-# Initialize Qt resources from file resources.py
-#from .resources import *
+from qgis.PyQt.QtWidgets import QAction, QDockWidget, QToolBar, QWidget
 
 # Import the code for the DockWidget
 from .libs.culvert_manager import CulvertManager
 from .libs.mesh_quality import MeshQuality
-import os.path
+
+# Initialize Qt resources from file resources.py
+# from .resources import *
 
 
 class TelemacTools:
@@ -49,14 +52,11 @@ class TelemacTools:
 
         # initialize plugin directory
         self.plugin_dir = os.path.dirname(__file__)
-        self.path_icon = os.path.join(os.path.dirname(__file__), 'icons/')
+        self.path_icon = os.path.join(os.path.dirname(__file__), "icons/")
 
         # initialize locale
-        locale = QSettings().value('locale/userLocale')[0:2]
-        locale_path = os.path.join(
-            self.plugin_dir,
-            'i18n',
-            'TelemacTools_{}.qm'.format(locale))
+        locale = QSettings().value("locale/userLocale")[0:2]
+        locale_path = os.path.join(self.plugin_dir, "i18n", "TelemacTools_{}.qm".format(locale))
 
         if os.path.exists(locale_path):
             self.translator = QTranslator()
@@ -65,13 +65,13 @@ class TelemacTools:
 
         # Declare instance attributes
         self.actions = []
-        self.menu = self.tr(u'&Telemac Tools')
+        self.menu = self.tr("&Telemac Tools")
         # TODO: We are going to let the user set this up in a future iteration
         self.toolbar = QToolBar()
-        #self.toolbar = self.iface.addToolBar(u'TelemacTools')
-        #self.toolbar.setObjectName(u'TelemacTools')
+        # self.toolbar = self.iface.addToolBar(u'TelemacTools')
+        # self.toolbar.setObjectName(u'TelemacTools')
 
-        #print "** INITIALIZING TelemacTools"
+        # print "** INITIALIZING TelemacTools"
 
         self.pluginIsActive = False
         self.dockwidget = None
@@ -89,8 +89,7 @@ class TelemacTools:
         :rtype: QString
         """
         # noinspection PyTypeChecker,PyArgumentList,PyCallByClass
-        return QCoreApplication.translate('TelemacTools', message)
-
+        return QCoreApplication.translate("TelemacTools", message)
 
     def add_action(
         self,
@@ -102,7 +101,8 @@ class TelemacTools:
         add_to_toolbar=False,
         status_tip=None,
         whats_this=None,
-        parent=None):
+        parent=None,
+    ):
         """Add a toolbar icon to the toolbar.
 
         :param icon_path: Path to the icon for this action. Can be a resource
@@ -157,37 +157,32 @@ class TelemacTools:
             self.toolbar.addAction(action)
 
         if add_to_menu:
-            self.iface.addPluginToMenu(
-                self.menu,
-                action)
+            self.iface.addPluginToMenu(self.menu, action)
 
         self.actions.append(action)
 
         return action
 
-
     def initGui(self):
         """Create the menu entries and toolbar icons inside the QGIS GUI."""
-        #self.postAct.triggered.connect(lambda: self.run("post"))
-        icon_path = os.path.join(self.plugin_dir, 'icon.png')
-        #icon_path = ':/plugins/telemac_tools/icon.png'
+        # self.postAct.triggered.connect(lambda: self.run("post"))
+        icon_path = os.path.join(self.plugin_dir, "icon.png")
+        # icon_path = ':/plugins/telemac_tools/icon.png'
         self.add_action(
-            icon_path,
-            text=self.tr(u'Culvert Manager'),
-            callback=lambda: self.run(1),
-            parent=self.iface.mainWindow())
+            icon_path, text=self.tr("Culvert Manager"), callback=lambda: self.run(1), parent=self.iface.mainWindow()
+        )
+        if Qgis.versionInt() >= 32200:
+            self.add_action(
+                icon_path,
+                text=self.tr("Mesh Quality Analysis"),
+                callback=lambda: self.run(2),
+                parent=self.iface.mainWindow(),
+            )
         self.add_action(
-            icon_path,
-            text=self.tr(u'Mesh Quality Analysis'),
-            callback=lambda: self.run(2),
-            parent=self.iface.mainWindow())
-        self.add_action(
-            icon_path,
-            text=self.tr(u'Telemac Tool 2'),
-            callback=lambda: self.run(3),
-            parent=self.iface.mainWindow())
+            icon_path, text=self.tr("Telemac Tool 2"), callback=lambda: self.run(3), parent=self.iface.mainWindow()
+        )
 
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
 
     def onClosePlugin(self):
         """Cleanup necessary items here when plugin dockwidget is closed"""
@@ -205,21 +200,18 @@ class TelemacTools:
 
         self.pluginIsActive = False
 
-
     def unload(self):
         """Removes the plugin menu item and icon from QGIS GUI."""
 
-        #print "** UNLOAD TelemacTools"
+        # print "** UNLOAD TelemacTools"
 
         for action in self.actions:
-            self.iface.removePluginMenu(
-                self.tr(u'&Telemac Tools'),
-                action)
+            self.iface.removePluginMenu(self.tr("&Telemac Tools"), action)
             self.iface.removeToolBarIcon(action)
         # remove the toolbar
         del self.toolbar
 
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
 
     def run(self, tool):
         """Run method that loads and starts the plugin"""
@@ -227,7 +219,7 @@ class TelemacTools:
         if not self.pluginIsActive:
             self.pluginIsActive = True
 
-            #print "** STARTING MenuMar"
+            # print "** STARTING MenuMar"
 
             # dockwidget may not exist if:
             #    first run of plugin

--- a/ui/mesh_quality.ui
+++ b/ui/mesh_quality.ui
@@ -20,6 +20,13 @@
       <string>Mesh</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="1">
+       <widget class="QgsMapLayerComboBox" name="mMapLayerComboBox">
+        <property name="showCrs">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="sizePolicy">
@@ -33,12 +40,6 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="cb_lay_mesh"/>
-      </item>
-      <item row="1" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_4"/>
-      </item>
      </layout>
     </widget>
    </item>
@@ -49,20 +50,120 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
+       <widget class="QgsCollapsibleGroupBox" name="chk_equilateralness">
+        <property name="title">
+         <string>Check faces equilateralness</string>
         </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Expanding</enum>
+        <property name="checkable">
+         <bool>true</bool>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
+        <layout class="QGridLayout" name="gridLayout_2">
+         <item row="1" column="1">
+          <widget class="QgsDoubleSpinBox" name="qdsb_bad_angle_2">
+           <property name="suffix">
+            <string>°</string>
+           </property>
+           <property name="value">
+            <double>30.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Angle threshold 1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QgsDoubleSpinBox" name="qdsb_bad_angle_1">
+           <property name="suffix">
+            <string>°</string>
+           </property>
+           <property name="value">
+            <double>20.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QgsDoubleSpinBox" name="qdsb_bad_angle_3">
+           <property name="suffix">
+            <string>°</string>
+           </property>
+           <property name="value">
+            <double>40.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Angle threshold 2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>Angle threshold 3</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QgsCollapsibleGroupBox" name="chk_min_size">
+        <property name="title">
+         <string>Check minimum faces size</string>
         </property>
-       </spacer>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_3">
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>TextLabel</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>Minimum face area</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>Minimum element length</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QgsDoubleSpinBox" name="qdsb_min_face_area">
+           <property name="value">
+            <double>5.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QgsDoubleSpinBox" name="qdsb_min_element_length">
+           <property name="value">
+            <double>2.000000000000000</double>
+           </property>
+           <property name="clearValue">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QgsDoubleSpinBox" name="mQgsDoubleSpinBox_6"/>
+         </item>
+        </layout>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -75,10 +176,38 @@
     </widget>
    </item>
    <item>
+    <widget class="QPushButton" name="btn_reset_marker">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Reset markers</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QTextEdit" name="log"/>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsmaplayercombobox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/ui/mesh_quality.ui
+++ b/ui/mesh_quality.ui
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>528</width>
+    <height>682</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="gb_mesh">
+     <property name="title">
+      <string>Mesh</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Layer</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="cb_lay_mesh"/>
+      </item>
+      <item row="1" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_4"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gb_culv">
+     <property name="title">
+      <string>Mesh Quality Analysis Parameters</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Expanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="btn_analyse_mesh">
+     <property name="text">
+      <string>Analyse mesh</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTextEdit" name="log"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/mesh_quality.ui
+++ b/ui/mesh_quality.ui
@@ -121,27 +121,6 @@
          <bool>true</bool>
         </property>
         <layout class="QGridLayout" name="gridLayout_3">
-         <item row="2" column="0">
-          <widget class="QLabel" name="label_7">
-           <property name="text">
-            <string>TextLabel</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_6">
-           <property name="text">
-            <string>Minimum face area</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_5">
-           <property name="text">
-            <string>Minimum element length</string>
-           </property>
-          </widget>
-         </item>
          <item row="1" column="1">
           <widget class="QgsDoubleSpinBox" name="qdsb_min_face_area">
            <property name="value">
@@ -159,8 +138,19 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
-          <widget class="QgsDoubleSpinBox" name="mQgsDoubleSpinBox_6"/>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>Minimum element length</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>Minimum face area</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>


### PR DESCRIPTION
Cette PR ajoute un outil d'analyse de qualité du maillage.

![image](https://user-images.githubusercontent.com/39594821/140900264-c3829ac5-8727-44bf-a124-aa388ac889be.png)

![image](https://user-images.githubusercontent.com/39594821/140900383-471368ce-5e96-4eaa-97b2-10e9b1ae58cb.png)

Plusieurs améliorations doivent encore être faites :

- Ajouter la légende des symboles
- Pouvoir parcourir les mailles fautives simplement (Suivante - Précédente)
- Synthèse de l'analyse dans le log

L'analyse en live edit n'est pas possible actuellement, les méthodes C++ ne sont (encore) pas exposées en Python (discussion avec Vincent Cloarec).

Modif apportées dans le code existant : 

- Appel de `self.dockwidget.widget().close()` lors de la fermeture du dock pour correctement fermer le widget. Dans le nouvel outils, utilisé pour effacer proprement tous les markers du canvas.
- Ajout de l'outil au menu si la version de Qgis est >= 3.22.0
